### PR TITLE
SimpleEmailConfirmationUserMixin is not really optional

### DIFF
--- a/simple_email_confirmation/models.py
+++ b/simple_email_confirmation/models.py
@@ -214,7 +214,10 @@ if getattr(settings, 'SIMPLE_EMAIL_CONFIRMATION_AUTO_ADD', True):
                 email = user.get_primary_email()
             else:
                 email = user.email
-            user.add_unconfirmed_email(email)
+            if hasattr(user, 'add_unconfirmed_email'):
+                user.add_unconfirmed_email(email)
+            else:
+                user.email_address_set.create_unconfirmed(email)
 
     # TODO: try to only connect this to the User model. We can't use
     #       get_user_model() here - results in import loop.

--- a/simple_email_confirmation/models.py
+++ b/simple_email_confirmation/models.py
@@ -210,7 +210,10 @@ if getattr(settings, 'SIMPLE_EMAIL_CONFIRMATION_AUTO_ADD', True):
     def auto_add(sender, **kwargs):
         if sender == get_user_model() and kwargs['created']:
             user = kwargs.get('instance')
-            email = user.get_primary_email()
+            if hasattr(user, 'get_primary_email'):
+                email = user.get_primary_email()
+            else:
+                email = user.email
             user.add_unconfirmed_email(email)
 
     # TODO: try to only connect this to the User model. We can't use


### PR DESCRIPTION
documentation says about SimpleEmailConfirmationUserMixin:

> Note: you don't strictly have to do this final step

but I fail to create user when SIMPLE_EMAIL_CONFIRMATION_AUTO_ADD is True:

```
  File ".../lib/python2.7/site-packages/simple_email_confirmation/models.py", line 207, in auto_add
    email = user.get_primary_email()
AttributeError: 'User' object has no attribute 'get_primary_email'
```

This pull request fixes the problem but it's not DRY. Maybe it's better to create some module level methods like this:

```
def get_primary_email(user):
    primary_email_field_name = getattr(user, 'primary_email_field_name', 'email')
    return getattr(user, primary_email_field_name)
```

and then use them in mixin and in signal handler
