### PR TITLE
key_length and confirmed emails

### DIFF
--- a/simple_email_confirmation/models.py
+++ b/simple_email_confirmation/models.py
@@ -92,11 +92,15 @@ class SimpleEmailConfirmationUserMixin(object):
     def add_unconfirmed_email(self, email, key_length=None):
         "Adds an unconfirmed email address and returns it's confirmation key"
         # if email already exists, let exception be thrown
-        address = self.email_address_set.create_unconfirmed(email, key_length=key_length)
+        address = self.email_address_set.create_unconfirmed(
+            email, key_length=key_length)
         return address.key
 
     def add_confirmed_email(self, email):
-        """Adds an email. If email was confirmed in some other way pass `confirmed=True`"""
+        """
+        Adds a confirmed email in some in case it was confirmed in some other way
+
+        """
         address = self.email_address_set.create_confirmed(email)
         return address.key
 
@@ -106,7 +110,7 @@ class SimpleEmailConfirmationUserMixin(object):
         address.reset_confirmation()
 
     def remove_email(self, email):
-        "Remove an email address and returns it's confirmation key"
+        "Remove an email address and return it's confirmation key"
         # if email already exists, let exception be thrown
         if email == self.get_primary_email():
             raise EmailIsPrimary()
@@ -126,7 +130,7 @@ class EmailAddressManager(models.Manager):
 
     def create_confirmed(self, email, user=None):
         "Create an email confirmation obj from the given email address obj"
-        user = user or self.instance
+        user = user or getattr(self, 'instance', None)
         if not user:
             raise ValueError('Must specify user or call from related manager')
         return self.create(
@@ -134,7 +138,7 @@ class EmailAddressManager(models.Manager):
 
     def create_unconfirmed(self, email, user=None, key_length=None):
         "Create an email confirmation obj from the given email address obj"
-        user = user or self.instance
+        user = user or getattr(self, 'instance', None)
         if not user:
             raise ValueError('Must specify user or call from related manager')
         key = self.generate_key(key_length=key_length)

--- a/simple_email_confirmation/models.py
+++ b/simple_email_confirmation/models.py
@@ -100,29 +100,17 @@ class SimpleEmailConfirmationUserMixin(object):
         address = self.email_address_set.confirm(confirmation_key, save=save)
         return address.email
 
-<<<<<<< HEAD
-    def add_unconfirmed_email(self, email, key_length=None):
-=======
     def add_confirmed_email(self, email):
         "Adds an email to the user that's already in the confirmed state"
         # if email already exists, let exception be thrown
         address = self.email_address_set.create_confirmed(email)
         return address.key
 
-    def add_unconfirmed_email(self, email):
->>>>>>> upstream/develop
+    def add_unconfirmed_email(self, email, key_length=None):
         "Adds an unconfirmed email address and returns it's confirmation key"
         # if email already exists, let exception be thrown
         address = self.email_address_set.create_unconfirmed(
             email, key_length=key_length)
-        return address.key
-
-    def add_confirmed_email(self, email):
-        """
-        Adds a confirmed email in some in case it was confirmed in some other way
-
-        """
-        address = self.email_address_set.create_confirmed(email)
         return address.key
 
     def add_email_if_not_exists(self, email):
@@ -152,11 +140,7 @@ class SimpleEmailConfirmationUserMixin(object):
         return address.reset_confirmation()
 
     def remove_email(self, email):
-<<<<<<< HEAD
-        "Remove an email address and return it's confirmation key"
-=======
         "Remove an email address"
->>>>>>> upstream/develop
         # if email already exists, let exception be thrown
         if email == self.get_primary_email():
             raise EmailIsPrimary()
@@ -179,31 +163,15 @@ class EmailAddressManager(models.Manager):
         user = user or getattr(self, 'instance', None)
         if not user:
             raise ValueError('Must specify user or call from related manager')
-        return self.create(
-            user=user, email=email, confirmed_at=now(), key=self.generate_key())
-
-<<<<<<< HEAD
-    def create_unconfirmed(self, email, user=None, key_length=None):
-        "Create an email confirmation obj from the given email address obj"
-        user = user or getattr(self, 'instance', None)
-=======
-    def create_confirmed(self, email, user=None):
-        "Create an email address in the confirmed state"
-        user = user or self.instance
-        if not user:
-            raise ValueError('Must specify user or call from related manager')
-        key = self.generate_key()
         now = timezone.now()
         # let email-already-exists exception propogate through
-        address = self.create(
-            user=user, email=email, key=key, set_at=now, confirmed_at=now,
+        return self.create(
+            user=user, email=email, set_at=now, confirmed_at=now, key=self.generate_key()
         )
-        return address
 
-    def create_unconfirmed(self, email, user=None):
+    def create_unconfirmed(self, email, user=None, key_length=None):
         "Create an email address in the unconfirmed state"
-        user = user or self.instance
->>>>>>> upstream/develop
+        user = user or getattr(self, 'instance', None)
         if not user:
             raise ValueError('Must specify user or call from related manager')
         key = self.generate_key(key_length=key_length)

--- a/simple_email_confirmation/tests.py
+++ b/simple_email_confirmation/tests.py
@@ -32,6 +32,21 @@ class EmailConfirmationTestCase(TestCase):
         self.assertNotEqual(key2, key3)
         self.assertNotEqual(key1, key3)
 
+    def test_error_create_no_user(self):
+        email = 'test@test.test'
+        self.assertRaises(ValueError, EmailAddress.objects.create_confirmed, email)
+        self.assertRaises(ValueError, EmailAddress.objects.create_unconfirmed, email)
+
+
+    def test_create_confirmed(self):
+        "Add a confirmed email for a User"
+        email = 'test@test.test'
+
+        self.user.add_confirmed_email(email)
+
+        address = self.user.email_address_set.get(email=email)
+        self.assertTrue(address.is_confirmed)
+
     def test_create_unconfirmed(self):
         "Add an unconfirmed email for a User"
         email = 'test@test.test'
@@ -47,6 +62,19 @@ class EmailConfirmationTestCase(TestCase):
         address = self.user.email_address_set.get(email=email)
         self.assertFalse(address.is_confirmed)
         self.assertEqual(address.confirmed_at, None)
+
+    def test_create_unconfirmed_custom_key_length(self):
+        """
+        Add an unconfirmed email for a User with custom 
+        key_length <= 40 in length
+        """
+        email = 'test@test.test'
+
+        self.user.add_unconfirmed_email(email, key_length=42)
+
+        address = self.user.email_address_set.get(email=email)
+        self.assertFalse(address.is_confirmed)
+        self.assertEqual(len(address.key), 40)
 
     def test_reset_confirmation(self):
         "Reset a confirmation key"

--- a/simple_email_confirmation/tests.py
+++ b/simple_email_confirmation/tests.py
@@ -32,22 +32,12 @@ class EmailConfirmationTestCase(TestCase):
         self.assertNotEqual(key2, key3)
         self.assertNotEqual(key1, key3)
 
-<<<<<<< HEAD
     def test_error_create_no_user(self):
         email = 'test@test.test'
         self.assertRaises(ValueError, EmailAddress.objects.create_confirmed, email)
         self.assertRaises(ValueError, EmailAddress.objects.create_unconfirmed, email)
 
 
-    def test_create_confirmed(self):
-        "Add a confirmed email for a User"
-        email = 'test@test.test'
-
-        self.user.add_confirmed_email(email)
-
-        address = self.user.email_address_set.get(email=email)
-        self.assertTrue(address.is_confirmed)
-=======
     def test_create_confirmed(self):
         "Add an unconfirmed email for a User"
         email = 'test@test.test'
@@ -57,7 +47,6 @@ class EmailConfirmationTestCase(TestCase):
         address = self.user.email_address_set.get(email=email)
         self.assertTrue(address.is_confirmed)
         self.assertEqual(address.key, key)
->>>>>>> upstream/develop
 
     def test_create_unconfirmed(self):
         "Add an unconfirmed email for a User"


### PR DESCRIPTION
So, first of all, I wanted to thank for a great app.
Couple things I thought could be useful to add
- ability to add confirmed emails in case they were confirmed in some other way (django-registration for instance)
- `key` field's `max_length` is set to 40, but there is no way to override length of generated key without  customizing the `EmailAddressManager`
  So this pull request addresses both issues.
  All tests pass, but no new tests was added.
