### PR TITLE
Update EmailAddress model's verbose_name_plural

### DIFF
--- a/simple_email_confirmation/models.py
+++ b/simple_email_confirmation/models.py
@@ -219,6 +219,7 @@ class EmailAddress(models.Model):
 
     class Meta:
         unique_together = (('user', 'email'),)
+        verbose_name_plural = "email addresses"
 
     def __unicode__(self):
         return u'{} <{}>'.format(self.user, self.email)


### PR DESCRIPTION
Added a verbose_name_plural Meta option for the EmailAddress model so it appears in the admin as "Email Addresses" instead of "Email Addresss".
