### PR TITLE
API-breaking change: don't early-import models and signals.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+*.pyo
+*.pyd
+*.egg-info

--- a/simple_email_confirmation/__init__.py
+++ b/simple_email_confirmation/__init__.py
@@ -1,13 +1,1 @@
-__version__ = '0.12'
-__all__ = [
-    'SimpleEmailConfirmationUserMixin',
-    'EmailAddress',
-    'email_confirmed',
-    'unconfirmed_email_created',
-    'primary_email_changed',
-]
-
-from .models import SimpleEmailConfirmationUserMixin, EmailAddress
-from .signals import (
-    email_confirmed, unconfirmed_email_created, primary_email_changed,
-)
+__version__ = '0.13'

--- a/simple_email_confirmation/tests/myproject/myapp/models.py
+++ b/simple_email_confirmation/tests/myproject/myapp/models.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.models import AbstractUser
-from simple_email_confirmation import SimpleEmailConfirmationUserMixin
+from simple_email_confirmation.models import SimpleEmailConfirmationUserMixin
 
 
 class User(SimpleEmailConfirmationUserMixin, AbstractUser):


### PR DESCRIPTION
This is required for Django 1.8+ compatibility.
