### PR TITLE
Adding app_labels to models

### DIFF
--- a/simple_email_confirmation/models.py
+++ b/simple_email_confirmation/models.py
@@ -199,6 +199,9 @@ class EmailAddressManager(models.Manager):
 
         return address
 
+    class Meta:
+        app_label = 'simple_email_confirmation'
+
 
 class EmailAddress(models.Model):
     "An email address belonging to a User"
@@ -223,6 +226,7 @@ class EmailAddress(models.Model):
     class Meta:
         unique_together = (('user', 'email'),)
         verbose_name_plural = "email addresses"
+        app_label = 'simple_email_confirmation'
 
     def __unicode__(self):
         return '{} <{}>'.format(self.user, self.email)


### PR DESCRIPTION
Due to some weirdness in how app loading works in Django 1.8, I was getting this warning:

```
RemovedInDjango19Warning: Model class simple_email_confirmation.models.EmailAddress
doesn't declare an explicit app_label and either isn't in an application in
INSTALLED_APPS or else was imported before its application was loaded. This will no longer
be supported in Django 1.9.
```

It's definitely in my `INSTALLED_APPS` - it has been there for years now, but it seems that due to the misterious way in which imports are interpreted by Django, it's giving me that warning.
