### PR TITLE
Fixed documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,17 +1,14 @@
 django-simple-email-confirmation
 ================================
 
-.. image:: https://api.travis-ci.org/mfogel/django-simple-email-confirmation.png?branch=develop
-   :target: https://travis-ci.org/mfogel/django-simple-email-confirmation
+.. image:: https://img.shields.io/travis/mfogel/django-simple-email-confirmation/develop.svg
+   :target: https://travis-ci.org/mfogel/django-simple-email-confirmation/
 
-.. image:: https://coveralls.io/repos/mfogel/django-simple-email-confirmation/badge.png?branch=develop
-   :target: https://coveralls.io/r/mfogel/django-simple-email-confirmation
+.. image:: https://img.shields.io/coveralls/mfogel/django-simple-email-confirmation/develop.svg
+   :target: https://coveralls.io/r/mfogel/django-simple-email-confirmation/
 
-.. image:: https://pypip.in/v/django-simple-email-confirmation/badge.png
-   :target: https://crate.io/packages/django-simple-email-confirmation/
-
-.. image:: https://pypip.in/d/django-simple-email-confirmation/badge.png
-   :target: https://crate.io/packages/django-simple-email-confirmation/
+.. image:: https://img.shields.io/pypi/dm/django-simple-email-confirmation.svg
+   :target: https://pypi.python.org/pypi/django-simple-email-confirmation/
 
 A Django app providing simple email confirmation.
 
@@ -81,7 +78,7 @@ Installation
     .. code:: python
 
         from django.contrib.auth.models import AbstractUser
-        from simple_email_confirmation import SimpleEmailConfirmationUserMixin
+        from simple_email_confirmation.models import SimpleEmailConfirmationUserMixin
 
         class User(SimpleEmailConfirmationUserMixin, AbstractUser):
             pass

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'simple_email_confirmation.tests.myproject',
         'simple_email_confirmation.tests.myproject.myapp',
     ],
-    install_requires=['django>=1.5.0'],
+    install_requires=['django>=1.7.0'],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Web Environment",

--- a/simple_email_confirmation/tests/myproject/myapp/models.py
+++ b/simple_email_confirmation/tests/myproject/myapp/models.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.models import AbstractUser
-from simple_email_confirmation import SimpleEmailConfirmationUserMixin
+from simple_email_confirmation.models import SimpleEmailConfirmationUserMixin
 
 
 class User(SimpleEmailConfirmationUserMixin, AbstractUser):


### PR DESCRIPTION
Hi, I was leading with an error produced by wrong documentation. 

Now Readme says 

> from simple_email_confirmation import SimpleEmailConfirmationUserMixin

but correct is 

> from simple_email_confirmation.models import SimpleEmailConfirmationUserMixin

So, I updated this and also requires in setup.py.

**Note:** It's convenient to update master branch with development because it's too outdate.
