### PR TITLE
Update documentation and requires in setup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ Installation
     .. code:: python
 
         from django.contrib.auth.models import AbstractUser
-        from simple_email_confirmation import SimpleEmailConfirmationUserMixin
+        from simple_email_confirmation.models import SimpleEmailConfirmationUserMixin
 
         class User(SimpleEmailConfirmationUserMixin, AbstractUser):
             pass

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'simple_email_confirmation.tests.myproject',
         'simple_email_confirmation.tests.myproject.myapp',
     ],
-    install_requires=['django>=1.5.0'],
+    install_requires=['django>=1.7.0'],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Web Environment",


### PR DESCRIPTION
Hi, I was leading with an error produced by wrong documentation. 

Now Readme says 

> from simple_email_confirmation import SimpleEmailConfirmationUserMixin

but correct is 

> from simple_email_confirmation.models import SimpleEmailConfirmationUserMixin

So, I updated this and also requires in setup.py.

**Note:** It's convenient to update master branch with development because it's too outdated.
