### PR TITLE
Stop using hardcoded `user.email` in `is_primary`

### DIFF
--- a/simple_email_confirmation/tests/myproject/myapp/models.py
+++ b/simple_email_confirmation/tests/myproject/myapp/models.py
@@ -4,3 +4,7 @@ from simple_email_confirmation.models import SimpleEmailConfirmationUserMixin
 
 class User(SimpleEmailConfirmationUserMixin, AbstractUser):
     pass
+
+
+class UserWithoutMixin(AbstractUser):
+	pass


### PR DESCRIPTION
Instead, use a new function `get_user_primary_email` that will use the
`get_primary_email` method if defined, else use the `email` attribute.

This new function is also used in the `auto_add` signal handler.

This new function is tested on the actual user test model, which uses
the `SimpleEmailConfirmationUserMixin`, and another model without the
mixin.