### PR TITLE
Makes coverage works by setting empty urls

### DIFF
--- a/simple_email_confirmation/tests/myproject/settings.py
+++ b/simple_email_confirmation/tests/myproject/settings.py
@@ -44,7 +44,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
 
-ROOT_URLCONF = 'project.urls'
+ROOT_URLCONF = 'simple_email_confirmation.tests.myproject.urls'
 
 WSGI_APPLICATION = 'project.wsgi.application'
 

--- a/simple_email_confirmation/tests/myproject/urls.py
+++ b/simple_email_confirmation/tests/myproject/urls.py
@@ -1,0 +1,1 @@
+urlpatterns = []


### PR DESCRIPTION
Not sure why the problem occurs only with coverage and not on normal
tests.

But here is the error, on travis, reproduced locally:

```
ImportError: No module named project.urls

ERROR: InvocationError:
'/home/twidi/dev/django-simple-email-confirmation/.tox/coverage/bin/coverage
run --include=*/simple_email_confirmation/*
--omit=*/migrations/*.py,*/south_migrations/*.py,*/tests/*.py
/home/twidi/dev/django-simple-email-confirmation/.tox/coverage/bin/django-admin.py
test simple_email_confirmation'
```

So I created a urls.py file in the test project.