### PR TITLE
Repair django checks failing on test app

### DIFF
--- a/simple_email_confirmation/tests/myproject/myapp/models.py
+++ b/simple_email_confirmation/tests/myproject/myapp/models.py
@@ -1,4 +1,6 @@
 from django.contrib.auth.models import AbstractUser
+from django.db import models
+
 from simple_email_confirmation.models import SimpleEmailConfirmationUserMixin
 
 
@@ -6,5 +8,5 @@ class User(SimpleEmailConfirmationUserMixin, AbstractUser):
     pass
 
 
-class UserWithoutMixin(AbstractUser):
-	pass
+class UserWithoutMixin(models.Model):
+       email = models.EmailField()

--- a/simple_email_confirmation/tests/tests.py
+++ b/simple_email_confirmation/tests/tests.py
@@ -219,9 +219,7 @@ class PrimaryEmailTestCase(TestCase):
     def test_getting_primary_email_without_mixin(self):
         "Try to get the primary email of a user model without the mixin"
         model = apps.get_model('myapp', 'UserWithoutMixin')
-        other_user = model.objects.create_user(
-            'myname', email='somebody@important.com',
-        )
+        other_user = model.objects.create(email='somebody@important.com')
         email = get_user_primary_email(other_user)
         self.assertEqual(email, other_user.email)
 


### PR DESCRIPTION
Because of the related name, we cannot have two models inheriting from
`AbstractUser`.

To correct this, the test model `UserWithoutMixin` is a simple model
with an email, which is the only thing needed for the test.