### PR TITLE
Unconfirmed EmailAddress will not be added when loading a fixture

### DIFF
--- a/simple_email_confirmation/models.py
+++ b/simple_email_confirmation/models.py
@@ -276,7 +276,7 @@ class EmailAddress(models.Model):
 # by default, auto-add unconfirmed EmailAddress objects for new Users
 if getattr(settings, 'SIMPLE_EMAIL_CONFIRMATION_AUTO_ADD', True):
     def auto_add(sender, **kwargs):
-        if sender == get_user_model() and kwargs['created']:
+        if sender == get_user_model() and kwargs['created'] and not kwargs['raw']:
             user = kwargs.get('instance')
             email = get_user_primary_email(user)
             if email:


### PR DESCRIPTION
While loading a fixture containing Users and corresponding EmailAddress object the `auto_add ` function should not create a new EmailAddress after User is created as it will be loaded later.


Loading a fixture causes an Integrity error:
`django.db.utils.IntegrityError: Problem installing fixture 'fixture.json': Could not load simple_email_confirmation.EmailAddress(pk=1): columns user_id, email are not unique`

Fixed using the solution for this SO question:
(https://stackoverflow.com/questions/3499791/how-do-i-prevent-fixtures-from-conflicting-with-django-post-save-signal-code)