### PR TITLE
SIMPLE_EMAIL_CONFIRMATION_KEY_LENGTH

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,7 @@ Installation
 #.  Change default settings (optional):
 
     By default, keys don't expire. If you want them to, set `settings.SIMPLE_EMAIL_CONFIRMATION_PERIOD` to a timedelta.
+
     .. code:: python
 
         from datetime import timedelta
@@ -100,13 +101,13 @@ Installation
 
     By default, auto-add unconfirmed EmailAddress objects for new Users. If you want to change this behaviour, set `settings.SIMPLE_EMAIL_CONFIRMATION_AUTO_ADD` to False.
 
-    .. code::python
+    .. code:: python
 
         SIMPLE_EMAIL_CONFIRMATION_AUTO_ADD = False
 
     By default, a length of keys is 12. If you want to change it, set `settings.SIMPLE_EMAIL_CONFIRMATION_KEY_LENGTH` to integer value (maximum 40).
 
-    .. code::python
+    .. code:: python
 
         SIMPLE_EMAIL_CONFIRMATION_KEY_LENGTH = 16
 

--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,28 @@ Installation
 
     Note: you don't strictly have to do this final step. Without this, you won't have the nice helper functions and properties on your `User` objects but the remainder of the app should function fine.
 
+#.  Change default settings (optional):
+
+    By default, keys don't expire. If you want them to, set `settings.SIMPLE_EMAIL_CONFIRMATION_PERIOD` to a timedelta.
+    .. code:: python
+
+        from datetime import timedelta
+
+        EMAIL_CONFIRMATION_PERIOD_DAYS = 7
+        SIMPLE_EMAIL_CONFIRMATION_PERIOD = timedelta(days=EMAIL_CONFIRMATION_PERIOD_DAYS)
+
+    By default, auto-add unconfirmed EmailAddress objects for new Users. If you want to change this behaviour, set `settings.SIMPLE_EMAIL_CONFIRMATION_AUTO_ADD` to False.
+
+    .. code::python
+
+        SIMPLE_EMAIL_CONFIRMATION_AUTO_ADD = False
+
+    By default, a length of keys is 12. If you want to change it, set `settings.SIMPLE_EMAIL_CONFIRMATION_KEY_LENGTH` to integer value (maximum 40).
+
+    .. code::python
+
+        SIMPLE_EMAIL_CONFIRMATION_KEY_LENGTH = 16
+
 
 Python/Django supported versions
 --------------------------------

--- a/simple_email_confirmation/models.py
+++ b/simple_email_confirmation/models.py
@@ -154,8 +154,11 @@ class EmailAddressManager(models.Manager):
 
     def generate_key(self):
         "Generate a new random key and return it"
-        # sticking with the django defaults
-        return get_random_string()
+        # By default, a length of keys is 12. If you want to change it, set
+        # settings.SIMPLE_EMAIL_CONFIRMATION_KEY_LENGTH to integer value (max 40).
+        return get_random_string(
+            length=min(getattr(settings, 'SIMPLE_EMAIL_CONFIRMATION_KEY_LENGTH', 12), 40)
+        )
 
     def create_confirmed(self, email, user=None):
         "Create an email address in the confirmed state"
@@ -198,7 +201,6 @@ class EmailAddressManager(models.Manager):
                 email_confirmed.send(sender=address.user, email=address.email)
 
         return address
-
 
 
 def get_user_primary_email(user):

--- a/simple_email_confirmation/tests/myproject/settings.py
+++ b/simple_email_confirmation/tests/myproject/settings.py
@@ -80,3 +80,6 @@ STATIC_URL = '/static/'
 
 # Custom user model
 AUTH_USER_MODEL = 'myapp.User'
+
+# Set the length of a confirmation key
+SIMPLE_EMAIL_CONFIRMATION_KEY_LENGTH = 32

--- a/simple_email_confirmation/tests/tests.py
+++ b/simple_email_confirmation/tests/tests.py
@@ -33,6 +33,13 @@ class EmailConfirmationTestCase(TestCase):
         self.assertNotEqual(key2, key3)
         self.assertNotEqual(key1, key3)
 
+    def test_key_length(self):
+        "Generate a few keys and compare them length with the settings"
+        generator = EmailAddress.objects.generate_key
+        for _ in range(3):
+            key = generator()
+            self.assertEqual(len(key), settings.SIMPLE_EMAIL_CONFIRMATION_KEY_LENGTH)
+
     def test_create_confirmed(self):
         "Add an unconfirmed email for a User"
         email = 'test@test.test'


### PR DESCRIPTION
It is useful to have a settings option for a change default key length.