### PR TITLE
Only allow tokens valid for the user whose email is being confirmed

### DIFF
--- a/simple_email_confirmation/models.py
+++ b/simple_email_confirmation/models.py
@@ -100,7 +100,7 @@ class SimpleEmailConfirmationUserMixin(object):
         Attempt to confirm an email using the given key.
         Returns the email that was confirmed, or raise an exception.
         """
-        address = self.email_address_set.confirm(confirmation_key, save=save)
+        address = self.email_address_set.confirm(confirmation_key, save=save, user=self)
         return address.email
 
     def add_confirmed_email(self, email):


### PR DESCRIPTION
This change restricts the valid email confirmation tokens to those associated with this user.  Which I think is the right thing to do, since you're confirming an email change for this user object.

This prevents the following scenario:
1) Attacker creates an email confirmation link using their own account
2) Attacker gets victim call confirmation link via a link/xss/other
3) Attacker now has updated victim's email