### PR TITLE
avoid IntegrityError on confirmation key collisions

### DIFF
--- a/simple_email_confirmation/models.py
+++ b/simple_email_confirmation/models.py
@@ -167,6 +167,8 @@ class EmailAddressManager(models.Manager):
             raise ValueError('Must specify user or call from related manager')
         key = self.generate_key()
         now = timezone.now()
+        while self.exists(key=key):
+            key = self.generate_key()
         # let email-already-exists exception propogate through
         address = self.create(
             user=user, email=email, key=key, set_at=now, confirmed_at=now,

--- a/simple_email_confirmation/models.py
+++ b/simple_email_confirmation/models.py
@@ -181,6 +181,8 @@ class EmailAddressManager(models.Manager):
         if not user:
             raise ValueError('Must specify user or call from related manager')
         key = self.generate_key()
+        while self.filter(key=key).exists():
+            key = self.generate_key()
         # let email-already-exists exception propogate through
         address = self.create(user=user, email=email, key=key)
         unconfirmed_email_created.send(sender=user, email=email)

--- a/simple_email_confirmation/models.py
+++ b/simple_email_confirmation/models.py
@@ -167,7 +167,7 @@ class EmailAddressManager(models.Manager):
             raise ValueError('Must specify user or call from related manager')
         key = self.generate_key()
         now = timezone.now()
-        while self.exists(key=key):
+        while self.filter(key=key).exists():
             key = self.generate_key()
         # let email-already-exists exception propogate through
         address = self.create(


### PR DESCRIPTION
This adds an extra database query, but is probably worth handling gracefully.